### PR TITLE
fix ambiguous symbol error for lib build

### DIFF
--- a/cpp/lib4ffi/primeapi.cpp
+++ b/cpp/lib4ffi/primeapi.cpp
@@ -5,7 +5,7 @@
 #include "exchange.h"
 #include "prime_sieve.h"
 #include "primeapi.h"
-using namespace std;
+//using namespace std;
 
 
 

--- a/cpp/prime4lib/exchange.h
+++ b/cpp/prime4lib/exchange.h
@@ -1,7 +1,7 @@
 #define _exchangeclass
 #include <iostream>
 #include <functional>
-using namespace std;
+//using namespace std;
 
 class Exchange {
 public:


### PR DESCRIPTION
- fix ambiguous symbol error because of exchange and std::exchange
